### PR TITLE
Ruby gem no doc tweak

### DIFF
--- a/jenkins-slave-jdk8-jhipster/Dockerfile
+++ b/jenkins-slave-jdk8-jhipster/Dockerfile
@@ -17,7 +17,7 @@ RUN npm install grunt
 RUN apt-get -y install ruby ruby-dev make g++
 
 # Install compass
-RUN gem install sass compass --no-ri --no-rdoc
+RUN gem install --no-document sass compass 
 
 # Install imageMagick
 RUN apt-get -y install imagemagick

--- a/jenkins-slave-jdk8-restx/Dockerfile
+++ b/jenkins-slave-jdk8-restx/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update
 #RUN apt-get dist-upgrade -q -y
 #RUN cat /etc/debian_version
 RUN apt-get -y install nodejs ruby2.4 ruby2.4-dev
-RUN gem install sass compass --no-ri --no-rdoc
+RUN gem install --no-document sass compass 
 # Install bower and grunt
 RUN npm install -g bower grunt grunt-cli
 # Install local grunt for tests

--- a/jenkins-slave-jekyll/Dockerfile
+++ b/jenkins-slave-jekyll/Dockerfile
@@ -28,4 +28,4 @@ RUN npm install -g gulp && \
     npm install -g grunt-cli && \
     npm install -g bower
 
-RUN gem install jekyll rdiscount kramdown
+RUN gem install --no-document jekyll rdiscount kramdown


### PR DESCRIPTION
Optimization tweak for ruby gems no doc while gems installation using
 "--no-document" . Also removal of depricated "--no-ri" and "--no-rdoc".

 More detail can be found at
 https://guides.rubygems.org/command-reference/#installupdate-options-2

 Signed-off-by: Pratik raj <rajpratik71@gmail.com>